### PR TITLE
fix-path-comparison

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source "https://rubygems.org"
 
 gem "octokit"
+gem 'pry-byebug', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,20 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    byebug (11.1.3)
+    coderay (1.1.3)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    method_source (1.0.0)
     multipart-post (2.1.1)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (3.1.0)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
@@ -18,6 +27,7 @@ PLATFORMS
 
 DEPENDENCIES
   octokit
+  pry-byebug
 
 BUNDLED WITH
    1.17.2

--- a/github-cat
+++ b/github-cat
@@ -75,11 +75,11 @@ class GithubCat
   end
 
   def each
-    filename = chomp_forward_slash(@path)
+    filename = @path.split('/').last
     results = client.search_code("org:#{@org} in:path #{filename}")
 
     results.items.each do |item|
-      next unless chomp_forward_slash(item[:path]) == filename
+      next unless [@path, '/' + @path].include?(item[:path])
 
       repo = item[:repository][:full_name]
       content = Base64.decode64(client.contents(repo, path: item[:path]).content)
@@ -87,10 +87,6 @@ class GithubCat
       result = { :repo => repo, :content => content }
       yield result
     end
-  end
-
-  def chomp_forward_slash(path)
-    path.split('/').last
   end
 end
 

--- a/github-cat
+++ b/github-cat
@@ -75,11 +75,11 @@ class GithubCat
   end
 
   def each
-    filename = @path.split('/').last
+    filename = chomp_forward_slash(@path)
     results = client.search_code("org:#{@org} in:path #{filename}")
 
     results.items.each do |item|
-      next unless item[:path] == @path
+      next unless chomp_forward_slash(item[:path]) == filename
 
       repo = item[:repository][:full_name]
       content = Base64.decode64(client.contents(repo, path: item[:path]).content)
@@ -87,6 +87,10 @@ class GithubCat
       result = { :repo => repo, :content => content }
       yield result
     end
+  end
+
+  def chomp_forward_slash(path)
+    path.split('/').last
   end
 end
 


### PR DESCRIPTION
When running `./github-cat grnhse .ruby-version`, `item[:path]` had a leading forward slash that broke match. Oddly, we're only able to reproduce this behavior on my Mac, and not on Dana's Linux. But fix works in both machines

![image](https://user-images.githubusercontent.com/6484961/101398382-fc5d6e80-389b-11eb-9067-97478c26405e.png)

With fix:
```
adam.barcan in github-cat on fix-path-comparison
aws:support(us-east-1) k8s:dev.usw2 ❯ bundle exec ./github-cat --json grnhse .ruby-version | jq .

[
  {
    "repo": "grnhse/dajoku_cli",
    "content": "2.6.3\n"
  },
  {
```

Without fix
```
adam.barcan in github-cat on master
aws:support(us-east-1) k8s:dev.usw2 ❯ bundle exec ./github-cat --json grnhse .ruby-version | jq .

[]
```
